### PR TITLE
Buildroot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Send a new PR to this repository on GitHub, append your application table. Radxa
 
 ## CM3 projects list:
 
-| Project Name:     |      |
+| Project Name:     | Buildroot support for CM3 + Radxa E23 |
 | ----------------- | ---- |
-| CM3 Model:        |      |
-| Project Hardware: |      |
-| Project Software: |      |
-| Other Notes:      |      |
+| CM3 Model:        | RM116-D1E0 |
+| Project Hardware: | RM116-D1E0 + Radxa E23 |
+| Project Software: | https://buildroot.org/ |
+| Other Notes:      | Assuming basic Linux support exists |
 
 


### PR DESCRIPTION
I would like to port [Buildroot](https://buildroot.org/) on CM3 + Radxa E23 carrier board.  Buildroot already supports rockpi-4, rockpi-n10, and rockpi-n8 out of the box.